### PR TITLE
Fix DM replies to use sender ID instead of bot's user ID

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -303,11 +303,14 @@ export async function handleKookMessage(params: {
       OriginatingTo: kookTo,
     });
 
+    // For DMs, target_id is the bot's own user ID, so we reply to senderId instead
+    const replyTarget = isGroup ? channelId : senderId;
+
     const { dispatcher, replyOptions, markDispatchIdle } = createKookReplyDispatcher({
       cfg,
       agentId: route.agentId,
       runtime: runtime as RuntimeEnv,
-      channelId,
+      channelId: replyTarget,
       replyToMessageId: event.msg_id,
       accountId: account.accountId,
       isDm: !isGroup,


### PR DESCRIPTION
## Summary
Fixed an issue where direct messages (DMs) were being sent to the bot's own user ID instead of the message sender's ID, preventing proper reply routing in DM conversations.

## Changes
- Added logic to determine the correct reply target based on message type:
  - For group messages: use `channelId` (existing behavior)
  - For DMs: use `senderId` instead of `channelId` (new behavior)
- Updated the `createKookReplyDispatcher` call to use the computed `replyTarget` instead of always using `channelId`

## Implementation Details
The issue occurred because in Kook's DM API, the `target_id` field is set to the bot's own user ID rather than the sender's ID. By checking the `isGroup` flag and conditionally using `senderId` for DMs, replies are now correctly routed to the message originator instead of creating a self-referential loop.

https://claude.ai/code/session_01B4exX7RSB1aVUofvf1Ynhm